### PR TITLE
Add support for airflow 2.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-RUN pip install apache-airflow==2.5.1
+RUN pip install apache-airflow==2.6.3
 ADD entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Validate and test DAGs, before deploying to production by creating an isolated Airflow on Docker Container with supplied variables and dependencies.
 
-Currently supports Airflow [v2.0.2](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.0.2), [v2.2.2](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.2.2), [v2.4.3](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.4.3) and [v2.5.1](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.5.1)
+Currently supports Airflow [v2.0.2](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.0.2), [v2.2.2](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.2.2), [v2.4.3](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.4.3), [v2.5.1](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.5.1), and [v2.6.3](https://github.com/micael-grilo/airflow-dags-test-action/releases/tag/v2.6.3)
 
 ![Main CI/CD Pipeline](https://github.com/micael-grilo/airflow-dags-test-action/workflows/Main%20CI/CD%20Pipeline/badge.svg)
 
@@ -21,7 +21,7 @@ Place in a `.yml` file such as this one in your `.github/workflows` folder. [Ref
 
 ```yml
 - name: 'Test Airflow DAGs'
-  uses: micael-grilo/airflow-dags-test-action@v2.5.1
+  uses: micael-grilo/airflow-dags-test-action@v2.6.3
     with:
       requirements-file: project/requirements.txt
       dags-path: project/dags


### PR DESCRIPTION
appreciate this project 🙏 

[looks like](https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt) 2.6.3 still uses `pytest==7.4.0`, so left that alone. 