### PR TITLE
Add pendulum to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11
 
+RUN pip install 'pendulum<3.0.0'
 RUN pip install apache-airflow==2.7.2
 RUN pip install connexion==2.14.2
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This change fixes docker builds, which are failing due to the [latest release of pendulum](https://github.com/sdispater/pendulum/releases/tag/3.0.0):

```sh
...
> [6/6] RUN airflow db init > /dev/null:                                                             
0.400 Traceback (most recent call last):                                                              
0.400   File "/usr/local/lib/python3.11/site-packages/airflow/settings.py", line 55, in <module>
0.400     TIMEZONE = pendulum.tz.timezone(tz)
0.400                ^^^^^^^^^^^^^^^^^^^^^^^^
0.400 TypeError: 'module' object is not callable
...
```